### PR TITLE
Fixed a bug related to a symbolic link of the generator

### DIFF
--- a/lib/generators/chanko/chanko_generator.rb
+++ b/lib/generators/chanko/chanko_generator.rb
@@ -31,8 +31,8 @@ class ChankoGenerator < Rails::Generators::NamedBase
 
   def create_js_files
     if options.js? && !options.coffee?
-      create_symlink('javascripts')
       template 'chanko.js', File.join("app", base_directory, file_name, "javascripts", "#{file_name}.js")
+      create_symlink('javascripts')
     end
   end
 

--- a/lib/generators/chanko/install/install_generator.rb
+++ b/lib/generators/chanko/install/install_generator.rb
@@ -21,8 +21,6 @@ Chanko::ActiveIf.files = active_if_files
 
       def create_symbolic_link
         inside(Rails.root) do
-          run("ln -ns ../../#{base_directory} app/assets/stylesheets/#{base_directory}")
-          run("ln -ns ../../#{base_directory} app/assets/javascripts/#{base_directory}")
           run("ln -ns ../app/#{base_directory} spec/#{base_directory}") if File.exists?(Rails.root.join("spec"))
           run("ln -ns ../app/#{base_directory} test/#{base_directory}") if File.exists?(Rails.root.join("test"))
         end
@@ -32,7 +30,7 @@ Chanko::ActiveIf.files = active_if_files
         directory "active_if", "lib/chanko/active_if"
       end
 
-      private 
+      private
       def base_directory
         ENV['CHANKOS_DIRECTORY'] || options[:directory].pluralize
       end


### PR DESCRIPTION
Because when: "chanko install", a symbolic link has been created in app / assets / ( javascript | stylesheets ) / chankos, had a conflict when you generate the Extention.

The cause was due to had gotten to target directory File.unlink is being used in Thor.create_link.
