### PR TITLE
scss template generates wrong html class

### DIFF
--- a/lib/generators/chanko/templates/chanko.scss
+++ b/lib/generators/chanko/templates/chanko.scss
@@ -1,6 +1,6 @@
 /* example
-.chanko_<%= file_name %> {
-  &.chanko_<%= file_name %>-callback_name {
+.ext_<%= file_name %> {
+  &.ext_<%= file_name %>-callback_name {
   }
 }
 */


### PR DESCRIPTION
template generates following html class.

```
.chanko_feature {
  &.chanko_feature-callback_name {
  }
}
```

but chanko's callback generates following html.

```
<div class="extension ext_feature ext_feature-callback_name"></div>
```
