### PR TITLE
Fix chancko_controller_spec generator templete

### DIFF
--- a/lib/generators/chanko/templates/chanko_controller_spec.rb
+++ b/lib/generators/chanko/templates/chanko_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe <%= class_name %>Controller, :type => :controller do
   before do
-    enable_chanko(:<%= file_name %>)
+    enable_ext(:<%= file_name %>)
   end
 
   it "success" do


### PR DESCRIPTION
gsub('enable_chanko', 'enable_ext')
(or it may be well to make an alias from enable_chanko to enable_ext)
