### PR TITLE
added Chanko.config.propagated_errors

### DIFF
--- a/lib/chanko/config.rb
+++ b/lib/chanko/config.rb
@@ -11,7 +11,7 @@ module Chanko
     include ActiveSupport::Configurable
 
     config_accessor :raise
-    config_accessor :propagate_errors
+    config_accessor :propagated_errors
     config_accessor :test
     config_accessor :cache_classes
     config_accessor :default_active_if
@@ -24,7 +24,7 @@ module Chanko
 
   configure do |config|
     config.raise = false
-    config.propagate_errors = []
+    config.propagated_errors = []
     config.test = Rails.env.test?
     config.cache_classes = Rails.application.config.cache_classes
     config.default_active_if = lambda { false }

--- a/lib/chanko/exception_notifier.rb
+++ b/lib/chanko/exception_notifier.rb
@@ -20,11 +20,11 @@ module Chanko
         Rails.logger.debug("Chanko::Exception #{message}\n#{backtrace}")
       end
 
-      propagate_errors = Chanko.config.propagate_errors
-      if payload[:exception] && propagate_errors.any?{|e| payload[:exception].kind_of?(e) }
+      propagated_errors = Chanko.config.propagated_errors
+      if payload[:exception] && propagated_errors.any?{|e| payload[:exception].kind_of?(e) }
         raise payload[:exception]
       end
-      if payload[:exception_klass] && propagate_errors.any?{|e| payload[:exception_klass].new.kind_of?(e) }
+      if payload[:exception_klass] && propagated_errors.any?{|e| payload[:exception_klass].new.kind_of?(e) }
         raise payload[:exception_klass]
       end
 

--- a/spec/lib/function_spec.rb
+++ b/spec/lib/function_spec.rb
@@ -21,8 +21,8 @@ describe "Chanko" do
       class ExceptionToNotPassThroughed < Exception; end
 
       before(:all) do
-        @config_save = Chanko.config.propagate_errors.dup
-        Chanko.config.propagate_errors = [ExceptionToPassThroughed]
+        @config_save = Chanko.config.propagated_errors.dup
+        Chanko.config.propagated_errors = [ExceptionToPassThroughed]
       end
 
       before do
@@ -47,7 +47,7 @@ describe "Chanko" do
       end
 
 
-      after(:all)  {  Chanko.config.propagate_errors = @config_save }
+      after(:all)  {  Chanko.config.propagated_errors = @config_save }
     end
 
     context 'controller' do


### PR DESCRIPTION
Added `Chanko.config.exceptions_to_pass_through` (Array). (**renamed**: → `propagated_errors`)

when exceptions in that Array raised, Chanko won't catch the exception.
