### PR TITLE
Change magic comment in template files

### DIFF
--- a/lib/generators/chanko/templates/chanko.rb
+++ b/lib/generators/chanko/templates/chanko.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module <%= class_name %>
   include Chanko::Unit
 

--- a/lib/generators/chanko/templates/chanko_controller_spec.rb
+++ b/lib/generators/chanko/templates/chanko_controller_spec.rb
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 =begin
 require 'spec_helper'
 

--- a/lib/generators/chanko/templates/chanko_helper.rb
+++ b/lib/generators/chanko/templates/chanko_helper.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module <%= class_name %>
   helpers do
     def helper_hello

--- a/lib/generators/chanko/templates/chanko_helper_spec.rb
+++ b/lib/generators/chanko/templates/chanko_helper_spec.rb
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 =begin
 require 'spec_helper'
 

--- a/lib/generators/chanko/templates/chanko_model.rb
+++ b/lib/generators/chanko/templates/chanko_model.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module <%= class_name %>
   module Models
     expand("<%= class_name.camelize %>") do

--- a/lib/generators/chanko/templates/chanko_model_spec.rb
+++ b/lib/generators/chanko/templates/chanko_model_spec.rb
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 =begin
 require 'spec_helper'
 


### PR DESCRIPTION
I changed magic comments in template files simply.
### from

``` ruby
# -*- coding: utf-8 -*-
```
### to

``` ruby
# coding: utf-8
```

And I added it to some files because they don't have any magic comments.
