### PR TITLE
Add development dependancy for Ruby 2.0.0

### DIFF
--- a/chanko.gemspec
+++ b/chanko.gemspec
@@ -25,6 +25,9 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'ruby-debug19', ['>= 0']
     s.add_development_dependency 'simplecov', ['>= 0.4.0']
     s.add_development_dependency 'factory_girl', ['=3.0.0']
+  elsif RUBY_VERSION =~ /\A2.0.*/
+    s.add_development_dependency 'simplecov', ['>= 0.4.0']
+    s.add_development_dependency 'factory_girl', ['=3.0.0']
   else
     s.add_development_dependency 'rcov'
     s.add_development_dependency 'ruby-debug', ['>= 0']


### PR DESCRIPTION
ruby-debug19, ruby-debugger and debugger require ruby header files,
but ruby_core_source and debugger-ruby_core_source does not include
Ruby2.0.0 header files yet, so skip install.
