### PR TITLE
Remove `unit` proxy method.

### DIFF
--- a/lib/chanko/method_proxy.rb
+++ b/lib/chanko/method_proxy.rb
@@ -8,7 +8,7 @@ module Chanko
     end
 
     module Methods
-      def unit(_unit_label=nil, &block)
+      def ext(_unit_label=nil, &block)
         unit_label = _unit_label || Chanko::Loader.current_scope
         raise NoExtError unless unit_label
 
@@ -38,7 +38,6 @@ module Chanko
           Chanko::Loader.pop_scope if _unit_label
         end
       end
-      alias_method :ext, :unit
     end
 
     class NullProxy

--- a/spec/lib/expand_spec.rb
+++ b/spec/lib/expand_spec.rb
@@ -75,7 +75,7 @@ describe Chanko do
         expander.class_eval { has_one :recipe, :foreign_key => 'user_id' }
         expander.attach(user_klass)
         user = user_klass.create!(:name => 'alice')
-        user.unit(:prefix).recipe.should be_blank
+        user.ext(:prefix).recipe.should be_blank
         user.create___prefix__recipe(:title => 'hello')
         Recipe.count(:conditions => {:user_id => user.id}).should == 1
       end
@@ -84,9 +84,9 @@ describe Chanko do
         expander.class_eval { has_many :recipes, :foreign_key => 'user_id' }
         expander.attach(user_klass)
         user = user_klass.create!(:name => 'alice')
-        user.unit(:prefix).recipes.should be_blank
-        user.unit(:prefix).recipes.create!(:title => 'hello')
-        user.unit(:prefix).recipes.should have(1).records
+        user.ext(:prefix).recipes.should be_blank
+        user.ext(:prefix).recipes.create!(:title => 'hello')
+        user.ext(:prefix).recipes.should have(1).records
       end
 
       it 'should use belongs_to association' do
@@ -94,7 +94,7 @@ describe Chanko do
         expander.attach(recipe_klass)
         user = user_klass.create!(:name => 'alice')
         recipe = recipe_klass.create!(:user_id => user.id, :title => 'hello')
-        recipe.unit(:prefix).user.id.should == user.id
+        recipe.ext(:prefix).user.id.should == user.id
       end
 
       it 'should use scope' do
@@ -106,8 +106,8 @@ describe Chanko do
         %w(alice bob).each { |name| User.create!(:name => name) }
 
         user_klass.should have(2).records
-        user_klass.unit(:prefix).named('alice').should have(1).records
-        user_klass.unit(:prefix).alice.should have(1).records
+        user_klass.ext(:prefix).named('alice').should have(1).records
+        user_klass.ext(:prefix).alice.should have(1).records
       end
 
       it 'should work with a block' do
@@ -139,8 +139,8 @@ describe Chanko do
           scope :icecream, lambda { where(:title => 'icecream') }
         end
         expander2.attach(AssociationProxyTestRecipe)
-        user_klass.where(:id => alice.id).first.unit(:prefix).recipes.unit(:prefix).icecream.size.should == 1
-        user_klass.where(:id => alice.id).first.unit(:prefix).recipes.unit(:prefix).icecream.first.id.should == alice_icecream.id
+        user_klass.where(:id => alice.id).first.ext(:prefix).recipes.ext(:prefix).icecream.size.should == 1
+        user_klass.where(:id => alice.id).first.ext(:prefix).recipes.ext(:prefix).icecream.first.id.should == alice_icecream.id
       end
     end
   end

--- a/spec/lib/helper_spec.rb
+++ b/spec/lib/helper_spec.rb
@@ -37,7 +37,7 @@ describe Chanko do
         klass.send(:include, Chanko::Helper)
       end.new
 
-      instance.unit(:helper_test).bar.should == 'bar'
+      instance.ext(:helper_test).bar.should == 'bar'
     end
   end
 

--- a/spec/lib/method_proxy_spec.rb
+++ b/spec/lib/method_proxy_spec.rb
@@ -9,7 +9,7 @@ describe Chanko do
       dummy_klass.new
     end
 
-    let(:proxy) { receiver.unit(:proxy_test) }
+    let(:proxy) { receiver.ext(:proxy_test) }
 
     before do
       mock_unit("ProxyTest")
@@ -50,17 +50,17 @@ describe Chanko do
         end
 
         receiver.instance_eval { class<<self; self; end }.class_eval { include Chanko::Helper }
-        receiver.unit(:proxy_test) do |unit|
+        receiver.ext(:proxy_test) do |unit|
           unit.should == ProxyTest
           Chanko::Loader.current_scope.should == :proxy_test
-          receiver.unit.hello.should == 'hello'
+          receiver.ext.hello.should == 'hello'
         end
       end
 
       it 'should raise error' do
         raise_chanko_exception
         expect {
-          receiver.unit(:proxy_test) do |unit|
+          receiver.ext(:proxy_test) do |unit|
             raise StandardError, 'error'
           end
         }.to raise_error(StandardError, 'error')
@@ -69,7 +69,7 @@ describe Chanko do
       it 'should not raise error when raise is repressed' do
         no_raise_chanko_exception
         expect {
-          receiver.unit(:proxy_test) do |unit|
+          receiver.ext(:proxy_test) do |unit|
             raise StandardError, 'error'
           end
         }.to_not raise_error(StandardError, 'error')
@@ -80,7 +80,7 @@ describe Chanko do
         begin
           ProxyTest.propagates_errors = true
           expect {
-            receiver.unit(:proxy_test) do |unit|
+            receiver.ext(:proxy_test) do |unit|
               raise StandardError, 'error'
             end
           }.to raise_error(StandardError, 'error')
@@ -98,12 +98,12 @@ describe Chanko do
       end
 
       it 'should return null proxy when non-existent unit is specified' do
-        null_proxy = receiver.unit(:missing)
+        null_proxy = receiver.ext(:missing)
         null_proxy.should be_kind_of(Chanko::MethodProxy::NullProxy)
       end
 
       it 'should always return nil' do
-        null_proxy = receiver.unit(:missing)
+        null_proxy = receiver.ext(:missing)
         null_proxy.hoge.should be_false
       end
     end
@@ -111,8 +111,8 @@ describe Chanko do
     context 'spec' do
       it 'use stub' do
         pending('stub doesnt work')
-        receiver.unit(:proxy_test).stub(:hello).and_return(1)
-        receiver.unit(:proxy_test).hello.should == 1
+        receiver.ext(:proxy_test).stub(:hello).and_return(1)
+        receiver.ext(:proxy_test).hello.should == 1
       end
     end
   end

--- a/spec/lib/test/test_tool_spec.rb
+++ b/spec/lib/test/test_tool_spec.rb
@@ -17,23 +17,23 @@ describe Chanko do
     describe 'active' do
       it 'should be activated' do
         enable_unit(:mock_test)
-        invoker.unit(:mock_test).should be_active
+        invoker.ext(:mock_test).should be_active
       end
 
       it 'should be deactivated' do
         disable_unit(:mock_test)
-        invoker.unit(:mock_test).should_not be_active
+        invoker.ext(:mock_test).should_not be_active
       end
 
       it 'should be activated with user_id' do
         user = mock("User")
         user.stub!(:id).and_return(1)
         enable_unit(:mock_test, 1)
-        invoker.unit(:mock_test).should be_active(:user => user)
+        invoker.ext(:mock_test).should be_active(:user => user)
 
         user2 = mock("User")
         user2.stub!(:id).and_return(2)
-        invoker.unit(:mock_test).should_not be_active(:user => user2)
+        invoker.ext(:mock_test).should_not be_active(:user => user2)
       end
 
       it 'should be deactivated with user_id' do
@@ -42,11 +42,11 @@ describe Chanko do
         enable_unit(:mock_test, 1)
         enable_unit(:mock_test, 2)
         disable_unit(:mock_test, 1)
-        invoker.unit(:mock_test).should_not be_active(:user => user)
+        invoker.ext(:mock_test).should_not be_active(:user => user)
 
         user2 = mock("User")
         user.stub!(:id).and_return(2)
-        invoker.unit(:mock_test).should be_active(:user => user)
+        invoker.ext(:mock_test).should be_active(:user => user)
       end
     end
   end


### PR DESCRIPTION
Chanko causes an error when a table has `unit` column. I propose with this pull request that we remove `unit` proxy method for the reason below:
- `unit` proxy method is undocumented
  - Instead, `ext` is documented.
- `unit` is too generic
- I guess almost all Chanko users actually don't use this.

What do you think of it?
