### PR TITLE
Use absolute path for view_path

### DIFF
--- a/lib/chanko/unit.rb
+++ b/lib/chanko/unit.rb
@@ -67,7 +67,7 @@ module Chanko
       end
 
       def view_path
-        "#{Config.units_directory_path}/#{unit_name}/views"
+        Rails.root.join("#{Config.units_directory_path}/#{unit_name}/views").to_s
       end
 
       def find_function(identifier, label)


### PR DESCRIPTION
Current Chanko doesn't work with `rails server -d`. (daemon mode)
In daemonized Rack::Server, `Dir.pwd` doesn't return `Rails.root` but always `"/"`.

(See: https://github.com/rack/rack/blob/master/lib/rack/server.rb#L322 )

So When I set `units_directory_path` as follows, then `"app/units"` is expanded as `"/app/units"` as absolute path, it causes Missing Partial error.

``` ruby
Chanko::Config.units_directory_path = "app/units"
```

This PR fixes this issue.
