### PR TITLE
Add Chanko::Config.propagated_errors

### DIFF
--- a/lib/chanko/config.rb
+++ b/lib/chanko/config.rb
@@ -7,6 +7,7 @@ module Chanko
         :cache_units,
         :compatible_css_class,
         :enable_logger,
+        :propagated_errors,
         :proxy_method_name,
         :raise_error,
         :resolver,
@@ -18,6 +19,7 @@ module Chanko
         self.backtrace_limit      = 10
         self.compatible_css_class = false
         self.enable_logger        = true
+        self.propagated_errors    = []
         self.proxy_method_name    = :unit
         self.raise_error          = Rails.env.development?
         self.resolver             = ActionView::OptimizedFileSystemResolver

--- a/lib/chanko/exception_handler.rb
+++ b/lib/chanko/exception_handler.rb
@@ -1,10 +1,37 @@
 module Chanko
-  module ExceptionHandler
-    class << self
-      def handle(exception, unit = nil)
-        Logger.debug(exception)
-        raise exception if unit.try(:raise_error?) || Config.raise_error
+  class ExceptionHandler
+    def self.handle(*args)
+      new(*args).handle
+    end
+
+    attr_reader :exception, :unit
+
+    def initialize(exception, unit = nil)
+      @exception = exception
+      @unit      = unit
+    end
+
+    def handle
+      if propagated?
+        raise exception
+      else
+        log
+        raise exception if raised?
       end
+    end
+
+    private
+
+    def propagated?
+      Config.propagated_errors.any? {|klass| exception.is_a?(klass) }
+    end
+
+    def raised?
+      unit.try(:raise_error?) || Config.raise_error
+    end
+
+    def log
+      Logger.debug(exception)
     end
   end
 end

--- a/spec/chanko/exception_handler_spec.rb
+++ b/spec/chanko/exception_handler_spec.rb
@@ -14,6 +14,27 @@ module Chanko
       Exception.new
     end
 
+    context "when Config.propagated_errors includes given error" do
+      before do
+        Config.propagated_errors << Exception
+      end
+
+      it "raises up error without any logging" do
+        Logger.should_not_receive(:debug)
+        expect { described_class.handle(error, insensitive_unit) }.to raise_error
+      end
+    end
+
+    context "when Config.propagated_errors does not include given error" do
+      before do
+        Config.propagated_errors << StandardError
+      end
+
+      it "raises up no error" do
+        expect { described_class.handle(error, insensitive_unit) }.not_to raise_error
+      end
+    end
+
     context "when Config.raise_error is false" do
       it "raises up no error" do
         expect { described_class.handle(error, insensitive_unit) }.not_to raise_error


### PR DESCRIPTION
To propagate arbitrary errors raised from Chanko::Unit.
