### PR TITLE
Determine scope with ancestry comparison

### DIFF
--- a/lib/chanko/unit.rb
+++ b/lib/chanko/unit.rb
@@ -76,7 +76,7 @@ module Chanko
 
       def find_function(identifier, label)
         scope     = ScopeFinder.find(identifier)
-        target    = scope.ancestors.find {|klass| scopes[klass] }
+        target    = scopes.keys.find {|klass| scope <= klass }
         functions = scopes[target]
         functions[label] if functions
       end


### PR DESCRIPTION
Instead of iterating through ancestors, determine the appropriate scope target by comparing ancestry with Module#<= for a minor performance improvement when invoking functions.

Naive benchmark of an invoke call like `view.invoke(:example_unit, :self, :type => :plain)` on  `10_000` repetitions gave the following results.

before:

```
   0.720000   0.000000   0.720000 (  0.731927)
--------------------------- total: 0.720000sec
```

after:

```
   0.650000   0.010000   0.660000 (  0.663861)
--------------------------- total: 0.660000sec
```

(a tiny improvement...)
