### PR TITLE
May need handmade eager-loading logic in production

### DIFF
--- a/lib/chanko/config.rb
+++ b/lib/chanko/config.rb
@@ -6,6 +6,7 @@ module Chanko
         :backtrace_limit,
         :cache_units,
         :compatible_css_class,
+        :eager_load,
         :enable_logger,
         :propagated_errors,
         :proxy_method_name,
@@ -19,6 +20,7 @@ module Chanko
         self.backtrace_limit      = 10
         self.compatible_css_class = false
         self.enable_logger        = true
+        self.eager_load           = Rails.env.production?
         self.propagated_errors    = []
         self.proxy_method_name    = :unit
         self.raise_error          = Rails.env.development?

--- a/lib/chanko/loader.rb
+++ b/lib/chanko/loader.rb
@@ -10,6 +10,12 @@ module Chanko
       def cache
         @cache ||= {}
       end
+
+      def eager_load_units!
+        Pathname.glob("#{Rails.root}/#{Config.units_directory_path}/*").select(&:directory?).each do |path|
+          load(path.to_s.split("/").last.to_sym) rescue nil
+        end
+      end
     end
 
     def initialize(name)

--- a/lib/chanko/railtie.rb
+++ b/lib/chanko/railtie.rb
@@ -13,5 +13,15 @@ module Chanko
         ::ActiveRecord::Associations::CollectionAssociation.send(:include, UnitProxyProvider)
       end
     end
+
+    if Chanko::Config.eager_load
+      initializer("chanko.prevent_units_directory_from_eager_loading", before: :set_autoload_paths) do |app|
+        Rails.configuration.eager_load_paths.delete(Rails.root.join(Chanko::Config.units_directory_path).to_s)
+      end
+
+      initializer("chanko.eager_load_units") do |app|
+        Chanko::Loader.eager_load_units!
+      end
+    end
   end
 end


### PR DESCRIPTION
### Why?

To prevent loading all ruby files in units directory (e.g. spec file).

By the default behavior of Rails (maybe in Rails 3.x or later), the booting process tries to recursively eager-load all .rb files in app directory using "*_/_.rb" glob pattern. This is not matter under normal use-case, but it comes to a problem if any unit directory includes .rb file that we need not to load in production env (e.g. app/units/foo/spec/requests/foo_spec.rb).
