### PR TITLE
Store current unit stack in thread local storage

### DIFF
--- a/lib/chanko/function.rb
+++ b/lib/chanko/function.rb
@@ -2,7 +2,7 @@ module Chanko
   class Function
     attr_reader :block, :unit, :label
 
-    THREAD_LOCAL_UNITS_KEY = :chanko_units
+    THREAD_LOCAL_UNITS_KEY = 'Chanko::Function.units'
 
     class << self
       def units


### PR DESCRIPTION
Since Rails 4.0, Rails itself became thread-safe and it enables
multi-threading by default in production and test (i.e., it doesn't
insert Rack::Lock middleware).
