### PR TITLE
Improve document about expanding class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ end
 ### models
 In models block, you can expand model features by `expand` method.
 The expanded methods are available via unit proxy like `User.unit.active`,
-and `User.find(params[:id]).unit.active?`, and so on.
+`User.find(params[:id]).unit.active?` or `User.unit.gc_all_soft_deleted_users`.
 
 ```ruby
 models do
@@ -143,6 +143,12 @@ models do
 
     def active?
       deleted_at.nil?
+    end
+
+    class_methods do
+      def gc_all_soft_deleted_users
+        where.not(deleted_at: nil).delete_all
+      end
     end
   end
 end

--- a/lib/generators/chanko/unit/templates/unit.rb.erb
+++ b/lib/generators/chanko/unit/templates/unit.rb.erb
@@ -48,7 +48,7 @@ module <%= class_name %>
   # ## models
   # In models block, you can expand model features by `expand` method.
   # The expanded methods are available via unit proxy like `User.unit.active`,
-  # and `User.find(params[:id]).unit.active?`, and so on.
+  # `User.find(params[:id]).unit.active?` or `User.unit.gc_all_soft_deleted_users`.
   #
   # ```
   # models do
@@ -57,6 +57,12 @@ module <%= class_name %>
   #
   #     def active?
   #       deleted_at.nil?
+  #     end
+  #
+  #     class_methods do
+  #       def gc_all_soft_deleted_users
+  #         where.not(deleted_at: nil).delete_all
+  #       end
   #     end
   #   end
   # end

--- a/spec/dummy/app/units/entry_deletion/entry_deletion.rb
+++ b/spec/dummy/app/units/entry_deletion/entry_deletion.rb
@@ -26,6 +26,12 @@ module EntryDeletion
       def soft_delete
         update_attributes(:deleted_at => Time.now)
       end
+
+      class_methods do
+        def gc_all_soft_deleted_users
+          where.not(deleted_at: nil).delete_all
+        end
+      end
     end
   end
 


### PR DESCRIPTION
`class_mehtods` was documented in version 1, but it was lost by V2
refactoring.

Exists in https://github.com/cookpad/chanko/commit/4e9ee55f937abc7cbb6b59013e76175324217a59#diff-eb140866c55c36f60acd6f79fb9c55ccR26,
but lost in https://github.com/cookpad/chanko/commit/293a94de562c8df2593c6cceab4721db2a04e38f#diff-a6626b1cac369377c7e3df8b539a1c7aR54.

I don't know why this code example was removed in V2 refactoring, but I think it is reasonal that we add `class_methods` example in template to show how to expand class methods.