### PR TITLE
Prepend MORITA shingo to gem.authors

### DIFF
--- a/chanko.gemspec
+++ b/chanko.gemspec
@@ -5,7 +5,7 @@ require "chanko/version"
 Gem::Specification.new do |gem|
   gem.name          = "chanko"
   gem.version       = Chanko::VERSION
-  gem.authors       = ["Ryo Nakamura"]
+  gem.authors       = ["MORITA shingo", "Ryo Nakamura"]
   gem.email         = ["tech@cookpad.com"]
   gem.description   = "Chanko is a Rails extension tool"
   gem.summary       = "Rails extension tool"


### PR DESCRIPTION
[At the big migration from Chanko v1 to v2](https://github.com/cookpad/chanko/commit/293a94de562c8df2593c6cceab4721db2a04e38f), I overwrote the jeweler-made gemspec with the auto-generated contents by mistake. It didn't mean it, so sorry.