### PR TITLE
Fix a deprecation warning in Rails 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## (Unreleased)
 * Drop support of ruby `1.9.x` and `2.0.0`.
+* Drop support of rails `3.x`.
 
 ## 2.0.8
 * Improve documentation about expanding class methods.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ it will be automatically hidden and fallback to its normal behavior.
 
 ## Requirements
 * Ruby >= 2.1.0
-* Rails >= 3.0.10 (and Rails4!)
+* Rails >= 4.0.0
 
 
 ## Usage

--- a/chanko.gemspec
+++ b/chanko.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>= 2.1.0'
 
-  gem.add_dependency "rails", ">= 3.0.10"
+  gem.add_dependency "rails", ">= 4.0.0"
   gem.add_development_dependency "coffee-rails", ">= 3.0.10"
   gem.add_development_dependency "coveralls"
   gem.add_development_dependency "jquery-rails"

--- a/lib/chanko/controller.rb
+++ b/lib/chanko/controller.rb
@@ -8,7 +8,7 @@ module Chanko
       def inherited(base)
         if Config.auto_reload && base.name == "ApplicationController"
           base.class_eval do
-            prepend_before_filter do
+            prepend_before_action do
               Chanko::Loader.cache.clear
             end
           end


### PR DESCRIPTION
If rails version using chanko is rails 5, use prepend_before_action. else use the prepend_before_filter.