### PR TITLE
Support zeitwerk

### DIFF
--- a/lib/chanko/loader.rb
+++ b/lib/chanko/loader.rb
@@ -48,8 +48,10 @@ module Chanko
     end
 
     def add_autoload_path
-      ActiveSupport::Dependencies.autoload_paths << autoload_path
-      ActiveSupport::Dependencies.autoload_paths.uniq!
+      unless Rails.autoloaders.zeitwerk_enabled?
+        ActiveSupport::Dependencies.autoload_paths << autoload_path
+        ActiveSupport::Dependencies.autoload_paths.uniq!
+      end
     end
 
     def autoload_path

--- a/lib/chanko/railtie.rb
+++ b/lib/chanko/railtie.rb
@@ -14,6 +14,12 @@ module Chanko
       end
     end
 
+    initializer("chanko.support_zeitwerk") do |app|
+      if Rails.autoloaders.zeitwerk_enabled?
+        Rails.autoloaders.main.collapse(Rails.root.join(Chanko::Config.units_directory_path, '*'))
+      end
+    end
+
     initializer("chanko.prevent_units_directory_from_eager_loading", before: :set_autoload_paths) do |app|
       if Chanko::Config.eager_load
         Rails.configuration.eager_load_paths.delete(Rails.root.join(Chanko::Config.units_directory_path).to_s)


### PR DESCRIPTION
https://github.com/cookpad/chanko/issues/56

> This line not work in rails 6.1.0.
https://github.com/cookpad/chanko/blob/master/lib/chanko/loader.rb#L51

```ruby
def add_autoload_path
  ActiveSupport::Dependencies.autoload_paths << autoload_path
  ActiveSupport::Dependencies.autoload_paths.uniq!
end
```

> Because `ActiveSupport::Dependencies.autoload_paths` is frozen.
https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-paths

---

I tried to support zeitwerk.
I confirmed behavior in rails 6.0.3.4.