### PR TITLE
Restore support for old Rails

### DIFF
--- a/lib/chanko/loader.rb
+++ b/lib/chanko/loader.rb
@@ -48,7 +48,7 @@ module Chanko
     end
 
     def add_autoload_path
-      unless Rails.autoloaders.zeitwerk_enabled?
+      unless Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
         ActiveSupport::Dependencies.autoload_paths << autoload_path
         ActiveSupport::Dependencies.autoload_paths.uniq!
       end

--- a/lib/chanko/railtie.rb
+++ b/lib/chanko/railtie.rb
@@ -15,7 +15,7 @@ module Chanko
     end
 
     initializer("chanko.support_zeitwerk") do |app|
-      if Rails.autoloaders.zeitwerk_enabled?
+      if Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
         Rails.autoloaders.main.collapse(Rails.root.join(Chanko::Config.units_directory_path, '*'))
       end
     end


### PR DESCRIPTION
`Rails.autoloaders` was introduced in Rails 6.0. Test if it is availabe before calling it for Rails 5.x.