### PR TITLE
Remove deprecated gem(quiet_assets)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-group :development, :test, :production do
-  gem "quiet_assets"
-end
-
 group :development, :test do
   gem "pry-rails"
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -48,6 +48,7 @@ module Dummy
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+    config.assets.quiet = true if ::Rails::VERSION::MAJOR >= 5
   end
 end
 


### PR DESCRIPTION
bundle install実行時、Resolving dependenciesのまま進まない問題に遭遇しました。
原因を切り分けたところ、すでにdeprecatedなGemであるquiet_assetsが含まれていると発生することが分かりました。
https://github.com/evrone/quiet_assets

元々がOptionalなGemですので、あまり深追いせずに削除します。