### PR TITLE
refactor loader and related spec

### DIFF
--- a/lib/chanko/loader.rb
+++ b/lib/chanko/loader.rb
@@ -63,7 +63,7 @@ module Chanko
         constantize
       rescue NameError
         # Chanko never raise error even if the constant fails to reference
-        nil
+        false
       end
 
       def constantize
@@ -125,7 +125,7 @@ module Chanko
       rescue Exception => exception
         ExceptionHandler.handle(exception)
         self.class.save_to_cache(@name, false)
-        nil
+        false
       end
 
       def load_from_cache

--- a/spec/chanko/loader_spec.rb
+++ b/spec/chanko/loader_spec.rb
@@ -21,7 +21,8 @@ module Chanko
 
       context "when loader has ever loaded specified unit" do
         it "load unit from cache", classic: true do
-          expect_any_instance_of(Chanko::Loader::ClassicLoader).to receive(:load_from_file).and_call_original
+          expect(Chanko::Loader::ClassicLoader).to receive(:load_from_cache).twice.and_call_original
+          expect(Chanko::Loader::ClassicLoader).to receive(:save_to_cache).with(anything, ExampleUnit).and_call_original
           Chanko::Loader.load(:example_unit)
           Chanko::Loader.load(:example_unit)
         end
@@ -33,7 +34,8 @@ module Chanko
         end
 
         it "load unit from cache", classic: true do
-          expect_any_instance_of(Chanko::Loader::ClassicLoader).to receive(:load_from_file).and_call_original
+          expect(Chanko::Loader::ClassicLoader).to receive(:load_from_cache).twice.and_call_original
+          expect(Chanko::Loader::ClassicLoader).to receive(:save_to_cache).with(anything, false).and_call_original
           Chanko::Loader.load(:non_existent_unit)
           Chanko::Loader.load(:non_existent_unit)
         end

--- a/spec/chanko/loader_spec.rb
+++ b/spec/chanko/loader_spec.rb
@@ -15,7 +15,7 @@ module Chanko
 
       context "when non-existent unit name is passed" do
         it "returns nil" do
-          expect(Chanko::Loader.load(:non_existent_unit)).to eq(nil)
+          expect(Chanko::Loader.load(:non_existent_unit)).to eq(false)
         end
       end
 
@@ -23,8 +23,8 @@ module Chanko
         it "load unit from cache", classic: true do
           expect(Chanko::Loader::ClassicLoader).to receive(:load_from_cache).twice.and_call_original
           expect(Chanko::Loader::ClassicLoader).to receive(:save_to_cache).with(anything, ExampleUnit).and_call_original
-          Chanko::Loader.load(:example_unit)
-          Chanko::Loader.load(:example_unit)
+          expect(Chanko::Loader.load(:example_unit)).to eq(ExampleUnit)
+          expect(Chanko::Loader.load(:example_unit)).to eq(ExampleUnit)
         end
       end
 
@@ -36,8 +36,8 @@ module Chanko
         it "load unit from cache", classic: true do
           expect(Chanko::Loader::ClassicLoader).to receive(:load_from_cache).twice.and_call_original
           expect(Chanko::Loader::ClassicLoader).to receive(:save_to_cache).with(anything, false).and_call_original
-          Chanko::Loader.load(:non_existent_unit)
-          Chanko::Loader.load(:non_existent_unit)
+          expect(Chanko::Loader.load(:non_existent_unit)).to eq(false)
+          expect(Chanko::Loader.load(:non_existent_unit)).to eq(false)
         end
       end
     end


### PR DESCRIPTION
https://github.com/cookpad/chanko/pull/64#discussion_r1035002869
上記で指摘されていたloader.rb及びspecのリファクタリングです。

- loadの処理を若干整理
- expect_any_instance_ofを排除
- cache処理の呼び出しチェック
- loadによるunitの読み込み失敗時、from_fileではnil、from_cacheではfalseを返していたのでfalseに統一