### PR TITLE
Bumpup to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 2.3.0
+* Support Rails 5.0, 5.1, 5,2, 6.0, 6,1.
+* Drop support of Rails 4.x.
+* Rails7 not supported yet.
+* Chanko::Config.eager_load has been replaced by a direct reference to Rails.configuration.eager_load.
+
 ## 2.2.1
 * Support Rails 7.0.
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ it will be automatically hidden and fallback to its normal behavior.
 
 
 ## Requirements
-* Ruby >= 2.1.0
-* Rails >= 4.0.0
+* Ruby >= 2.6.0
+* Rails >= 5.0.0
 
 
 ## Usage

--- a/chanko.gemspec
+++ b/chanko.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>= 2.6.0'
 
-  gem.add_dependency "rails", ">= 4.0.0"
+  gem.add_dependency "rails", ">= 5.0.0"
   gem.add_development_dependency "byebug"
   gem.add_development_dependency "coffee-rails", ">= 3.0.10"
   gem.add_development_dependency "jquery-rails"

--- a/gemfiles/Gemfile_rails_5.0.rb.lock
+++ b/gemfiles/Gemfile_rails_5.0.rb.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    chanko (2.2.1)
-      rails (>= 4.0.0)
+    chanko (2.3.0)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile_rails_5.1.rb.lock
+++ b/gemfiles/Gemfile_rails_5.1.rb.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    chanko (2.2.1)
-      rails (>= 4.0.0)
+    chanko (2.3.0)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile_rails_5.2.rb.lock
+++ b/gemfiles/Gemfile_rails_5.2.rb.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    chanko (2.2.1)
-      rails (>= 4.0.0)
+    chanko (2.3.0)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile_rails_6.0.rb.lock
+++ b/gemfiles/Gemfile_rails_6.0.rb.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    chanko (2.2.1)
-      rails (>= 4.0.0)
+    chanko (2.3.0)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile_rails_6.1.rb.lock
+++ b/gemfiles/Gemfile_rails_6.1.rb.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    chanko (2.2.1)
-      rails (>= 4.0.0)
+    chanko (2.3.0)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/chanko/version.rb
+++ b/lib/chanko/version.rb
@@ -1,3 +1,3 @@
 module Chanko
-  VERSION = "2.2.1"
+  VERSION = "2.3.0"
 end


### PR DESCRIPTION
gemのversion更新のため、README、gemspecなどを書き換えました。
サポートバージョンを変更してたため、MINORを上げます。
