### PR TITLE
Rails6のdevelopment環境でResolverのcacheがclearされない問題の修正

### DIFF
--- a/lib/chanko/config.rb
+++ b/lib/chanko/config.rb
@@ -1,5 +1,3 @@
-require "chanko/resolver/no_cache_file_system_resolver"
-
 module Chanko
   class NoCacheFileSystemResolver < ActionView::FileSystemResolver
     def query(path, details, formats, locals, cache:)
@@ -30,11 +28,11 @@ module Chanko
         self.proxy_method_name    = :unit
         self.raise_error          = Rails.env.development?
 
-        if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7')
+        if Rails::VERSION::MAJOR >= 7
           self.resolver = ActionView::FileSystemResolver
         else
           if Rails.env.development?
-            self.resolver = Chanko::Resolver::NoCacheFileSystemResolver
+            self.resolver = Chanko::NoCacheFileSystemResolver
           else
             self.resolver = ActionView::OptimizedFileSystemResolver
           end

--- a/lib/chanko/config.rb
+++ b/lib/chanko/config.rb
@@ -23,7 +23,7 @@ module Chanko
         self.propagated_errors    = []
         self.proxy_method_name    = :unit
         self.raise_error          = Rails.env.development?
-        self.resolver = file_resolver_for_using_version_of_rails
+        self.resolver = resolver_for_using_rails_and_env
         self.units_directory_path = "app/units"
       end
 
@@ -35,12 +35,12 @@ module Chanko
         @resolved_units_directory_path ||= Rails.root.join(@units_directory_path).to_s
       end
 
-      def file_resolver_for_using_version_of_rails
+      def resolver_for_using_rails_and_env
         return ActionView::FileSystemResolver if Rails::VERSION::MAJOR >= 7
         return Chanko::Resolver::NoCacheFileSystemResolver if Rails.env.development?
         return ActionView::OptimizedFileSystemResolver
       end
-      private :file_resolver_for_using_version_of_rails
+      private :resolver_for_using_rails_and_env
     end
 
     reset

--- a/lib/chanko/resolver/no_cache_file_system_resolver.rb
+++ b/lib/chanko/resolver/no_cache_file_system_resolver.rb
@@ -1,0 +1,11 @@
+module Chanko
+  module Resolver
+    if defined?(ActionView::OptimizedFileSystemResolver)
+      class NoCacheFileSystemResolver < ActionView::OptimizedFileSystemResolver
+        def query(path, details, formats, locals, cache:)
+          super(path, details, formats, locals, cache: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/chanko/resolver/no_cache_file_system_resolver.rb
+++ b/lib/chanko/resolver/no_cache_file_system_resolver.rb
@@ -1,10 +1,12 @@
+unless defined?(ActionView::FileSystemResolver)
+  require 'action_view/template/resolver'
+end
+
 module Chanko
   module Resolver
-    if defined?(ActionView::OptimizedFileSystemResolver)
-      class NoCacheFileSystemResolver < ActionView::OptimizedFileSystemResolver
-        def query(path, details, formats, locals, cache:)
-          super(path, details, formats, locals, cache: false)
-        end
+    class NoCacheFileSystemResolver < ActionView::FileSystemResolver
+      def query(path, details, formats, locals, cache:)
+        super(path, details, formats, locals, cache: false)
       end
     end
   end


### PR DESCRIPTION
# 問題
Chanko(unit)を呼び出しているViewファイルを変更・保存しリロードすると、例外が発生する。
https://github.com/cookpad/chanko/issues/69

### 発生環境
Rails6 + development(autoload) + classic および zeitwerk

### 再現方法
```
# app/units/sample/sample.rb
class Sample
  ...
  scope(:view) do
    function(:hello) do
      render '/hello'
    end
  end
end

# views/pages/main.html.erb
<%= invoke(:sample, :hello) %>
```
1. pages/mainを開く
2. main.html.erbに空行などを入れるとして保存をする
3. リロードをする
4. 下記のエラーが発生する

>   [Chanko] ActionView::Template::Error - undefined method `_app_units_sample_views__hello_html_erb__3197552978688360732_19600' for #<ActionView::Base:0x00000000009ad8>

# 原因
Rails6 + developmentではリロードのたび、下記のコードで「探索パスに登録済みのViewsに関するcacheをclear」します。
しかし、unitのviewは処理を抜けるタイミングで、都度探索パスからunshiftしているため、cacheが残ります。

https://github.com/rails/rails/blob/main/actionview/lib/action_view/cache_expiry.rb
https://github.com/rails/rails/blob/main/actionview/lib/action_view/lookup_context.rb#L73-L80

# 対応
cacheを利用しないFileResolverを定義し、development時のChankoのViewファイルに利用します。

利用の判定は`Rails.env.development?`に従います。
`config.action_view.cache_template_loading`に従う事も考えましたが、初期化の順序の問題ですんなり動きませんでした。
https://railsguides.jp/configuring.html#config-action-view-cache-template-loading

とはいえ今現在も下記の通りRails.envで判定しているため、大きな変化はありません。
https://github.com/cookpad/chanko/blob/master/lib/chanko/config.rb#L17