### PR TITLE
Do not include setup/test command as executable

### DIFF
--- a/chanko.gemspec
+++ b/chanko.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/cookpad/chanko"
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>= 2.6.0'


### PR DESCRIPTION
#64 の中で bin ディレクトリを作っており、bin/setup と bin/test が chanko gem のコマンドとして含まれてしまっているのを直します。

@eudoxa @cookpad/infra レビューお願いします