### PR TITLE
[Breaking change] Chanko no longer modifies view_paths to add or remove its own view path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,6 @@ end
 = invoke(:example_unit, :render_example)
 ```
 
-```
--# app/units/example_unit/views/_example.html.slim
-= foo
-```
-
 ## Unit
 You can see [the real example of an unit module file](https://github.com/cookpad/chanko/blob/master/spec/dummy/app/units/entry_deletion/entry_deletion.rb).
 
@@ -120,16 +115,7 @@ end
 ```
 
 ### render
-The view path app/units/example_unit/views is added into view_paths in invoking.
-So you can render app/units/example_unit/views/_example.html.slim in invoking.
-
-```ruby
-scope(:view) do
-  function(:render_example) do
-    render "/example", :foo => hello("world")
-  end
-end
-```
+In its previous version, Chanko added the views path of the unit to Rails' view file search. However, it no longer does that. If you still want to place the views path under the unit, please create a symbolic link under app/views/units and refer to it.
 
 ### models
 In models block, you can expand model features by `expand` method.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ end
 ```
 
 ### render
-In its previous version, Chanko added the views path of the unit to Rails' view file search. However, it no longer does that. If you still want to place the views path under the unit, please create a symbolic link under app/views/units and refer to it.
+In version 2 and earlier, Chanko extended Rails' search path to include the views path of the unit. This functionality has been discontinued. To maintain the views path under the unit, you will need to manually create a symbolic link in app/views/units to access it.
 
 ### models
 In models block, you can expand model features by `expand` method.

--- a/lib/chanko/function.rb
+++ b/lib/chanko/function.rb
@@ -22,12 +22,10 @@ module Chanko
 
     def invoke(context, options = {})
       with_unit_stack(context) do
-        with_unit_view_path(context) do
-          capture_exception(context) do
-            result = context.instance_eval(&block)
-            result = decorate(result, context, options[:type]) if context.view? && result.present?
-            result
-          end
+        capture_exception(context) do
+          result = context.instance_eval(&block)
+          result = decorate(result, context, options[:type]) if context.view? && result.present?
+          result
         end
       end
     end
@@ -57,13 +55,6 @@ module Chanko
     ensure
       self.class.units.pop
       context.units.pop
-    end
-
-    def with_unit_view_path(context)
-      context.view_paths.unshift unit.resolver if context.respond_to?(:view_paths)
-      yield
-    ensure
-      context.view_paths.paths.shift if context.respond_to?(:view_paths)
     end
 
     def capture_exception(context)

--- a/lib/chanko/unit.rb
+++ b/lib/chanko/unit.rb
@@ -70,10 +70,6 @@ module Chanko
         UnitProxy.generate_prefix(unit_name)
       end
 
-      def view_path
-        Rails.root.join("#{Config.units_directory_path}/#{unit_name}/views").to_s
-      end
-
       def find_function(identifier, label)
         scope     = ScopeFinder.find(identifier)
         target    = scope.ancestors.find {|klass| scopes[klass] }
@@ -91,10 +87,6 @@ module Chanko
 
       def shared_methods
         @shared_methods ||= {}
-      end
-
-      def resolver
-        @resolver ||= Config.resolver.new(view_path)
       end
 
       def extender

--- a/lib/generators/chanko/unit/templates/unit.rb.erb
+++ b/lib/generators/chanko/unit/templates/unit.rb.erb
@@ -34,13 +34,11 @@ module <%= class_name %>
   # ```
 
   # ## render
-  # In addition, the view path "<%= "#{directory}/views" %>" is added into view_paths.
-  # So you can render <%= "#{directory}/views/_example.html.erb" %> in invoking.
-  #
+  # If you want to place the views path under the unit, create a symbolic link under app/views/units and refer to it.
   # ```
   # scope(:view) do
   #   function(:function_name) do
-  #     render "/example", :foo => "bar"
+  #     render "/units/<%= your_unit_name.underscore %>/example", :foo => "bar"
   #   end
   # end
   # ```

--- a/spec/chanko/function_spec.rb
+++ b/spec/chanko/function_spec.rb
@@ -15,10 +15,6 @@ module Chanko
         def units
           @units ||= []
         end
-
-        def path
-          view_paths.first.to_s
-        end
       end
       klass.new
     end
@@ -32,12 +28,7 @@ module Chanko
         def units
           @units ||= []
         end
-
-        def path
-          view_paths.first.to_s
-        end
       end
-
       klass.with_view_paths([], {}, nil)
     end
 
@@ -50,16 +41,6 @@ module Chanko
       end
     end
 
-    let(:context_without_view_paths) do
-      Class.new do
-        include Chanko::Invoker
-
-        def units
-          @units ||= []
-        end
-      end.new
-    end
-
     let(:options) do
       { :type => :plain }
     end
@@ -67,19 +48,6 @@ module Chanko
     describe ".invoke" do
       it "invokes block with given context and stacked unit" do
         expect(described_class.new(unit, :label) { current_unit }.invoke(context, options)).to eq(unit)
-      end
-
-      context "when context is a view" do
-        it "invokes with unit's view path" do
-          expect(described_class.new(unit, :label) { path }.invoke(context, options)).to eq(unit.view_path)
-        end
-      end
-
-      context "when context does not have view_paths" do
-        it "invokes successfully" do
-          expect(described_class.new(unit, :label) { "test" }.
-            invoke(context_without_view_paths, options)).to eq("test")
-        end
       end
     end
   end

--- a/spec/chanko/unit_spec.rb
+++ b/spec/chanko/unit_spec.rb
@@ -245,11 +245,5 @@ module Chanko
         expect(ExampleModel.__example_unit_user).to eq([:class_name => "User"])
       end
     end
-
-    describe ".view_path" do
-      it "returns path for its view directory" do
-        expect(unit.view_path).to eq("#{Config.units_directory_path}/example_unit/views")
-      end
-    end
   end
 end

--- a/spec/dummy/app/views/units/example_unit
+++ b/spec/dummy/app/views/units/example_unit
@@ -1,0 +1,1 @@
+../../../../fixtures/units/example_unit/views

--- a/spec/fixtures/units/example_unit/example_unit.rb
+++ b/spec/fixtures/units/example_unit/example_unit.rb
@@ -27,7 +27,7 @@ module ExampleUnit
     end
 
     function(:render) do
-      render_to_string :partial => "/test", :locals => { :local => "test" }
+      render_to_string :partial => "/units/example_unit/test", :locals => { :local => "test" }
     end
 
     function(:nesting_locals_outer) do
@@ -78,7 +78,7 @@ module ExampleUnit
     end
 
     function(:render) do
-      render "/test", :local => "test"
+      render "/units/example_unit/test", :local => "test"
     end
 
     function(:blank) do


### PR DESCRIPTION
Rails 7.1で、viewの探索対象を管理するPathSet#pathsがfreezeされました。この変更でChankoの利用可能viewを動的に管理する仕組みが動かなくなります。

この仕組みはUnitのviewを外から不用意に利用する事を避けるためでしたが、無理をして維持する価値はおそらくないため、今回を機に関連コードと機能を削除します。

今後、Chankoはviewsに関して何の仕組みも持ちません。代替する管理方法の一例として、他のassetsと同様にapp/views/の下にシンボリックリンクを作成する方法をREADMEに追加しました。

### Before
> touch app/units/my_unit/views/_example.html.erb
```ruby
# my_unit.rb
scope(:view) do
  function(:function_name) do
    render "/example"
  end
end
```

### After
> touch app/units/my_unit/views/_example.html.erb
> ln -s app/units/my_unit/views/ app/views/units/my_unit/
```ruby
# my_unit.rb
scope(:view) do
  function(:function_name) do
    render "/units/my_unit/example"
  end
end
```
