### PR TITLE
fix generator code

### DIFF
--- a/lib/generators/chanko/unit/templates/unit.rb.erb
+++ b/lib/generators/chanko/unit/templates/unit.rb.erb
@@ -14,7 +14,7 @@ module <%= class_name %>
   # ```
 
   # ## raise_error
-  # `raise_error` is used to force an unit to raise up errors occured in invoking.
+  # `raise_error` is used to force an unit to raise up errors occurred in invoking.
   # You can force to raise up errors also by `Config.raise_error`.
   #
   # ```
@@ -38,7 +38,7 @@ module <%= class_name %>
   # ```
   # scope(:view) do
   #   function(:function_name) do
-  #     render "/units/<%= your_unit_name.underscore %>/example", :foo => "bar"
+  #     render "/units/<%= file_name.underscore %>/example", :foo => "bar"
   #   end
   # end
   # ```

--- a/lib/generators/chanko/unit/unit_generator.rb
+++ b/lib/generators/chanko/unit/unit_generator.rb
@@ -6,44 +6,53 @@ module Chanko
       source_root File.expand_path("../templates", __FILE__)
 
       def create_unit_directory
-        empty_directory(directory)
+        empty_directory(unit_directory)
       end
 
       def create_unit_file
-        template("unit.rb.erb", "#{directory}/#{file_name}.rb")
+        template("unit.rb.erb", "#{unit_directory}/#{file_name}.rb")
       end
 
-      def create_views_directory
-        create_file("#{directory}/views/.gitkeep", "")
+      def create_views_unit_directory
+        create_file("#{unit_directory}/views/.gitkeep", "")
       end
 
       ASSETS_TYPES.each do |type|
-        define_method("create_#{type}_directory") do
-          create_file("#{directory}/#{type}/.gitkeep", "")
+        define_method("create_#{type}_unit_directory") do
+          create_file("#{unit_directory}/#{type}/.gitkeep", "")
         end
-      end
 
-      ASSETS_TYPES.each do |type|
-        define_method("create_#{type}_symlink") do
+        define_method("create_#{type}_unit_symlink") do
           create_assets_symlink(type)
         end
+      end
+
+      def create_views_symlink
+        from = "app/views/#{units_directory_name}/#{file_name}"
+        to   = "../../../#{relative_unit_directory}/views"
+        create_link(from, to)
       end
 
       private
 
       def create_assets_symlink(type)
-        from = "app/assets/#{type}/#{directory_name}/#{file_name}"
-        to   = "../../../../#{directory}/#{type}"
+        from = "app/assets/#{type}/#{units_directory_name}/#{file_name}"
+        to   = "../../../../#{relative_unit_directory}/#{type}"
         create_link(from, to)
       end
 
-      def directory
+      def relative_unit_directory
+        Pathname.new(unit_directory).relative_path_from(Rails.root)
+      end
+
+      def unit_directory
         "#{Chanko::Config.units_directory_path}/#{file_name}"
       end
 
-      def directory_name
+      def units_directory_name
         Chanko::Config.units_directory_path.split("/").last
       end
     end
   end
 end
+


### PR DESCRIPTION
分割のために閉じた下記PRのうち、Generatorの修正分です。
https://github.com/cookpad/chanko/pull/79

- generatorでviewsのsymlinkを生成するように変更
  - generatorのsymlinkのパスが壊れていた問題を修正

## この後の流れ
1. Modelの拡張機能を削除 https://github.com/cookpad/chanko/pull/82
2. READMEの更新
3. メジャーバージョン更新
