### PR TITLE
update requirement and bumpup version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.0.0
 * Support Rails 6,1. 7.0, 7.1.
 * Support Ruby >= 3.0.
-* Drop support for Raiils below 6.0.
+* Drop support for Rails below 6.0.
 * Drop support for Ruby 2.
 * Drop support for classic loader.
 * The functionality to extend the view_paths has been discontinued.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## Unreleased
+## 3.0.0
 * Support Rails 6,1. 7.0, 7.1.
-* Drop support for Raiils below 6.0
-* Drop support for Ruby 2
-* Drop support for classic loader
+* Support Ruby >= 3.0.
+* Drop support for Raiils below 6.0.
+* Drop support for Ruby 2.
+* Drop support for classic loader.
 * The functionality to extend the view_paths has been discontinued.
 * The functionality to extend the models has been discontinued.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.0.0
 * Support Rails 6,1. 7.0, 7.1.
 * Support Ruby >= 3.0.
-* Drop support for Rails below 6.0.
+* Drop support for Rails <= 6.0.
 * Drop support for Ruby 2.
 * Drop support for classic loader.
 * The functionality to extend the view_paths has been discontinued.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ When any errors are raised from chanko's features,
 it will be automatically hidden and fallback to its normal behavior.
 
 ## Requirements
-* Ruby >= 2.6.0
-* Rails >= 5.0.0
+* Ruby >= 3.0.0
+* Rails >= 6.1.0
 
 ## Usage
 Add to your Gemfile.

--- a/lib/chanko/version.rb
+++ b/lib/chanko/version.rb
@@ -1,3 +1,3 @@
 module Chanko
-  VERSION = "2.3.0"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
## 概要
リリースに備え、CHANGELOGのUnreleasedを3.0.0に変更します。
マージ後にGemをリリースします。

  * Support Rails 6,1. 7.0, 7.1.
  * Support Ruby >= 3.0.
  * Drop support for Rails below 6.0.
  * Drop support for Ruby 2.
  * Drop support for classic loader.
  * The functionality to extend the view_paths has been discontinued.
  * The functionality to extend the models has been discontinued.
